### PR TITLE
Develop

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,7 @@
   package = "netlify-plugin-inline-functions-env"
   [plugins.inputs]
     buildEvent = "onPreBuild"
-    include = ["OPENSVM_RPC_LIST"]
+    include = ["OPENSVM_RPC_LIST", "OPENSVM_RPC_LIST_2"]
 
 # Handle static assets
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,8 +13,6 @@
 # Handle Next.js
 [[plugins]]
   package = "@netlify/plugin-nextjs"
-  [plugins.inputs]
-    useServerBuild = true
 
 # Handle environment variables for SVM RPC
 [[plugins]]


### PR DESCRIPTION
## Summary by Sourcery

Update Netlify build configuration to include an additional environment variable and remove an obsolete setting.

Build:
- Remove the `useServerBuild` input from the next.js plugin configuration.
- Add `OPENSVM_RPC_LIST_2` to the environment variables included in the build process using the `netlify-plugin-inline-functions-env` plugin config