### PR TITLE
Fix RPC error response id

### DIFF
--- a/app/api/solana-rpc/route.ts
+++ b/app/api/solana-rpc/route.ts
@@ -186,7 +186,8 @@ export async function POST(request: NextRequest) {
         code: -32000,
         message
       },
-      id: 1
+      id: body.id
     }, { status });
   }
 }
+


### PR DESCRIPTION
## Summary
- ensure the Solana RPC route echoes the request `id` in error responses

## Testing
- `npm test` *(fails: jest not found)*